### PR TITLE
ci: enforce the code coverage thresholds

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -56,6 +56,8 @@ branches:
       required_pull_request_reviews: null
       required_status_checks:
         strict: true
-        contexts: ['Test']
+        # 'status check - Code Coverage' is the name the coverage action
+        # publishes under - it prefixes whatever check-name it is given.
+        contexts: ['Test', 'status check - Code Coverage']
       enforce_admins: false
       restrictions: null

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
           python -m pip install -r requirements.txt
       - name: Test
         run: |
-          coverage run --omit=tests/\* -m pytest --verbose --junit-xml tests.xml
+          coverage run --branch --omit=tests/\* -m pytest --verbose --junit-xml tests.xml
           coverage xml -o coverage.xml
       - name: Upload Test Results
         uses: actions/upload-artifact@v7
@@ -128,7 +128,11 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           summary-file: './coverage-results/Summary.md'
           check-name: 'Code Coverage'
+          # Both thresholds must be non-zero. The action forces the status
+          # check to a 'neutral' conclusion if either is left at 0, which
+          # stops the line threshold from ever blocking a merge.
           line-threshold: 80
+          branch-threshold: 75
       - name: Comment PR with Version Impact
         uses: thollander/actions-comment-pull-request@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,7 +132,7 @@ jobs:
           # check to a 'neutral' conclusion if either is left at 0, which
           # stops the line threshold from ever blocking a merge.
           line-threshold: 80
-          branch-threshold: 75
+          branch-threshold: 70
       - name: Comment PR with Version Impact
         uses: thollander/actions-comment-pull-request@v3
         with:


### PR DESCRIPTION
The `Code Coverage` status check has reported `neutral` on every PR — including all eleven dependabot PRs merged today — so the 80% line threshold has never actually gated anything.

## Why it was never enforced

**1. The action discards the line result when either threshold is 0.**

`process-code-coverage-summary` computes each coverage type separately, then combines them (`src/main.js`):

```js
// :227  a threshold of 0 makes that type 'neutral'
if (infoToReturn.threshold === 0) {
  infoToReturn.conclusion = 'neutral';
}

// :248  any neutral drags the whole check to neutral
} else if (info.branch.conclusion == 'neutral' || info.line.conclusion == 'neutral') {
  info.statusCheckConclusion = 'neutral';
}
```

`branch-threshold` was never set, so it defaulted to `0` → branch is `neutral` → the **whole check** is `neutral`, no matter what line coverage did. The PR comment still rendered `PASSED` against the 80% line threshold, which is why it looked like it was working.

**2. The check was not required.** `required_status_checks.contexts` listed only `Test`, so even a `failure` conclusion would not have blocked a merge.

## Changes

- **`branch-threshold: 70`** so neither threshold is 0 and the check resolves to a real `success`/`failure`
- **`coverage run --branch`** so branch data is actually collected — without it the report has 0 branches, and any non-zero branch threshold would fail instantly
- **`status check - Code Coverage` added to required contexts.** That is the literal check name: the action prefixes whatever `check-name` you give it (`src/main.js:136`, `` const name = `status check - ${checkName}` ``)

## Threshold choice

Measured on a **clean checkout**, which is what CI does:

| | Actual | Threshold | Headroom |
| --- | --- | --- | --- |
| Line | 94.8% | 80% | ~15 pts |
| Branch | 76.9% (20/26) | 70% | ~7 pts |

A first pass used 75% for branch, based on a local measurement of 92.3%. That figure was wrong: a leftover `dist/` directory covers the "clear existing output dir" branch at `blog/generate.py:23-30`, which CI never reaches because it always starts from a clean checkout. Deleting `dist/` locally reproduces CI exactly (94.8% / 76.9%), so the threshold was lowered to 70 to leave real margin.

## Effect

Once merged, a PR that drops line coverage below 80% or branch coverage below 70% will publish a `failure` conclusion on a required check and be blocked from merging. Dependabot auto-merge is subject to the same gate.
