### PR TITLE
ci: make the deploy script idempotent and drop the wget typo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,10 +46,10 @@ jobs:
           port: 22
           script: |
             cd /srv
-            wget wget https://github.com/jamiefdhurst/blog/releases/download/${{ steps.version.outputs.value }}/blog-${{ steps.version.outputs.value }}.zip
-            unzip blog-${{ steps.version.outputs.value }}.zip -d blog-${{ steps.version.outputs.value }}/
-            rm blog
-            rm blog-*.zip
+            wget https://github.com/jamiefdhurst/blog/releases/download/${{ steps.version.outputs.value }}/blog-${{ steps.version.outputs.value }}.zip
+            unzip -o blog-${{ steps.version.outputs.value }}.zip -d blog-${{ steps.version.outputs.value }}/
+            rm -f blog
+            rm -f blog-*.zip
             ln -s blog-${{ steps.version.outputs.value }} blog
             service nginx reload
       - name: Update deployment status (success)


### PR DESCRIPTION
Four one-word fixes to the remote deploy script in `deploy.yml`. All were visible in the v1.5.1 re-deploy that ran earlier today.

## The changes

```diff
-wget wget https://github.com/.../blog-${version}.zip
-unzip blog-${version}.zip -d blog-${version}/
-rm blog
-rm blog-*.zip
+wget https://github.com/.../blog-${version}.zip
+unzip -o blog-${version}.zip -d blog-${version}/
+rm -f blog
+rm -f blog-*.zip
```

**`wget wget`** — wget accepts multiple URLs, so it tried to resolve a host literally named `wget`, failed, then downloaded the real asset:

```
--2026-08-12 08:17:50--  http://wget/
Resolving wget (wget)... failed: Temporary failure in name resolution.
wget: unable to resolve host address 'wget'
```

Functionally harmless — deploys have always worked — but it prints a resolution failure in every deploy log, which makes a healthy deploy look broken.

**`unzip` → `unzip -o`** — this is the one with teeth. When the target directory already exists, unzip prompts to replace, and over a non-interactive SSH session the prompt reads EOF and declines everything:

```
replace blog-v1.5.1/2022-01-08_motivation-for-side-projects.html? [y]es, [n]o, [A]ll, [N]one, [r]ename:  NULL
(EOF or read error, treating as "[N]one" ...)
```

The step still exits 0, so the deploy reports success having copied **nothing**. It doesn't affect normal releases, where each version unzips into a directory that doesn't exist yet — but any re-deploy of an existing version is a silent no-op today.

**`rm` → `rm -f`** — both `rm blog` and `rm blog-*.zip` fail if the symlink or the archives are absent, which risks leaving the script part-way through with the symlink already gone.

## Testing

Deploy changes can't be exercised without deploying. This PR does not trigger one: `Build` only fires on pushes touching `*.py`, `*.md`, `articles/**`, `blog/**`, `docker/**`, `tests/**`, `requirements.txt` or `setup.cfg`, and `Deploy` chains off `Build`. Merging this changes nothing until the next real release, which is when the new script first runs.

The YAML was parsed and the resulting remote script rendered to confirm it is well-formed.