### PR TITLE
fix: restore article intros, fix mobile viewport, unstick footer year

### DIFF
--- a/blog/generate.py
+++ b/blog/generate.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import shutil
 import sys
@@ -12,7 +13,7 @@ env = Environment(
 
 def render_template(file, **kwargs):
     template = env.get_template(file)
-    return template.render(**kwargs, version=VERSION)
+    return template.render(**kwargs, version=VERSION, year=datetime.date.today().year)
 
 def generate(articles_dir=ARTICLES_DIR, dist_dir=DIST_DIR):
 

--- a/blog/templates/base.html
+++ b/blog/templates/base.html
@@ -4,7 +4,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta charset="UTF-8" />
     <title>Jamie Hurst's Blog {% block title %}{% endblock %}</title>
-    <meta name="viewport" content="device-width" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     <meta name="description" content="Jamie Hurst - Software and System Engineer, Enthusiast of Terrible Cars" />
     <link rel="stylesheet" type="text/css" href="/static/css/default.min.css?v={{ version }}" />
@@ -30,7 +30,7 @@
             {% block content %}{% endblock %}
         </div>
     </main>
-    <footer role="contentinfo">&copy; Copyright Jamie Hurst 2021-2024<br />System {{ version }}</footer>
+    <footer role="contentinfo">&copy; Copyright Jamie Hurst 2021-{{ year }}<br />System {{ version }}</footer>
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-217639974-1"></script>
     <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('config', 'UA-217639974-1');</script>
 </body>

--- a/blog/templates/view.html
+++ b/blog/templates/view.html
@@ -7,6 +7,11 @@
         <p class="date">
             <span itemprop="dateCreated pubdate datePublished" content="{{ article.get_date().isoformat() }}">Posted on {{ article.get_date().strftime('%A %B %-d, %Y') }}</span>
         </p>
+        {% if article.get_summary() %}
+        <div class="summary">
+            <p>{{ article.get_summary()|safe }}</p>
+        </div>
+        {% endif %}
         <div class="content" itemprop="mainEntityOfPage">
             {{ article.get_content_only()|safe }}
         </div>


### PR DESCRIPTION
First pass from the blog review — the three highest-impact, lowest-risk items. Analytics was dropped from this pass; see the note at the bottom.

## 1. Mobile viewport was never set

```diff
-<meta name="viewport" content="device-width" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
```

The viewport meta parses comma-separated `key=value` pairs. `device-width` on its own has no key, so it was ignored and **no viewport was set at all**. Mobile browsers fell back to a ~980px layout viewport and scaled the page down to fit.

Knock-on effect: `@media (min-width: 768px)` matched (980 > 768), so the browser laid out at the 16px desktop base and *then* shrank everything by roughly 390/980 — putting body text at around 6–7 effective pixels on a phone. Given Google indexes mobile-first, this was both a usability and a ranking problem.

## 2. Every article was missing its opening paragraph

Summaries are written as an `## h2` and stripped from the body by `get_content_only()` (`articles.py:24-30`), so they appeared on the index and nowhere else. Anyone arriving from search or a shared link — most readers — started mid-argument. The sustainability article opened on:

> "A lot of what's been written on this topic falls into one of two camps..."

with nothing on the page establishing what "this topic" was. That affected all 25 articles.

The summary is now rendered on the article page as a lead paragraph ahead of the content. Two details worth noting:

- It is emitted as a `<p>`, not the source `<h2>`, so a 60-word sentence is no longer announced as a heading by screen readers — that also clears part of the heading-hierarchy item from the review.
- `get_content_only()` is unchanged, so the summary still appears exactly **once** (verified in the generated output).

## 3. Footer year

`2021-2024` hardcoded, in 2026. Now derived from the current date via a `year` variable added alongside `version` in `render_template()`, so it can't go stale again.

## Verification

Generated the full site and checked the output:

- viewport renders `width=device-width, initial-scale=1`
- footer renders `2021-2026`
- article page opens with the summary, present exactly once, as a `<p>`
- homepage unchanged — summary still appears once there
- 19/19 tests pass

All 25 articles have a summary, so the `{% if %}` fallback doesn't trigger in production; the no-summary path is covered by the `2022-01-02_test-2` fixture and its existing test.

## Note on analytics

The review flagged the UA tag as dead. That was wrong — requesting `gtag/js?id=UA-217639974-1` returns a config containing `G-5LMNLZMP56`, so Google's connected site tag is redirecting the old tag ID to a live GA4 property and data is being collected normally. No change made. The optional tidy-up would be swapping the ID to the GA4 one it already resolves to, removing the dependency on Google's compatibility shim.

## Deployment

This is a `fix:` commit, so merging will bump to **v1.5.2**, cut a release and deploy to production. It will also be the first run of the repaired deploy script from #133.