### PR TITLE
fix: render the hero image above the article summary

### DIFF
--- a/blog/articles.py
+++ b/blog/articles.py
@@ -22,11 +22,16 @@ class Article:
         return self.contents
 
     def get_content_only(self):
+        '''Body without the title, summary or hero image - those are rendered
+        separately so that the article page matches the index layout'''
         title = self.find_title.search(self.contents)
         summary = self.find_summary.search(self.contents)
+        image = self.find_image.search(self.contents)
         contents = self.contents.replace(title.group(0), '')
         if summary:
-            return contents.replace(summary.group(0), '')
+            contents = contents.replace(summary.group(0), '')
+        if image:
+            contents = contents.replace(image.group(0), '', 1)
         return contents
 
     def get_date(self):

--- a/blog/templates/view.html
+++ b/blog/templates/view.html
@@ -7,9 +7,10 @@
         <p class="date">
             <span itemprop="dateCreated pubdate datePublished" content="{{ article.get_date().isoformat() }}">Posted on {{ article.get_date().strftime('%A %B %-d, %Y') }}</span>
         </p>
-        {% if article.get_summary() %}
+        {% if article.get_image() or article.get_summary() %}
         <div class="summary">
-            <p>{{ article.get_summary()|safe }}</p>
+            {% if article.get_image() %}<p>{{ article.get_image()|safe }}</p>{% endif %}
+            {% if article.get_summary() %}<p>{{ article.get_summary()|safe }}</p>{% endif %}
         </div>
         {% endif %}
         <div class="content" itemprop="mainEntityOfPage">

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -43,15 +43,18 @@ def test_article_get_contents():
 def test_article_get_content_only():
     sut = Article('tests/articles/', '2022-01-01_test-1.md')
     assert '<h1>Test 1</h1>' not in sut.get_content_only()
-    assert '<img alt="Placeholder" src="/static/placeholder.png" />' in sut.get_content_only()
+    assert '<img alt="Placeholder" src="/static/placeholder.png" />' not in sut.get_content_only()
     assert '<h2>A test article that has very little inside of it.</h2>' not in sut.get_content_only()
     assert '<p>They were just sucked into space.' in sut.get_content_only()
+    # The hero image is stripped from the body but still available separately
+    assert '<img alt="Placeholder" src="/static/placeholder.png" />' == sut.get_image()
 
 def test_article_get_content_only_no_summary():
     sut = Article('tests/articles/', '2022-01-02_test-2.md')
     assert '<h1>Test 1</h1>' not in sut.get_content_only()
-    assert '<img alt="Placeholder" src="/static/placeholder.png" />' in sut.get_content_only()
+    assert '<img alt="Placeholder" src="/static/placeholder.png" />' not in sut.get_content_only()
     assert '<p>Worf, It\'s better than music.' in sut.get_content_only()
+    assert '<img alt="Placeholder" src="/static/placeholder.png" />' == sut.get_image()
 
 def test_article_get_date():
     sut = Article('tests/articles/', '2022-01-01_test-1.md')


### PR DESCRIPTION
Follow-up to #134. The summary block it added sat *above* the hero image, inverting the order used on the index — so moving from the index to an article made the content jump.

## Cause

The hero image is part of the rendered markdown body, and the summary was inserted before the body. Order came out as:

```
index:    h1 → date → [image, summary]
article:  h1 → date → [summary] → content(image, body…)
```

## Fix

The article page now mirrors the index exactly — hero image, then summary, then body:

```
index:    h1 → date → [image, summary]
article:  h1 → date → [image, summary] → content(body…)
```

The image is rendered explicitly alongside the summary and stripped from the body, so it isn't duplicated. Reusing the same `.summary` wrapper as the index means both pages pick up identical styling with no CSS change — the existing `img` rule is nested under `.summary, .content`.

## Safety of stripping the first image

`get_image()` returns the first `<p><img …></p>`, so stripping it is only correct if the first image is always the hero. Checked all 25 articles: every one has an image above its summary line, so the first match is always the hero. It is stripped with `count=1`, leaving in-body images alone.

Verified against the live v1.5.2 page:

| | Live (v1.5.2) | This build |
| --- | --- | --- |
| Terraform article `<img>` tags | 16 | 16 |
| Hero occurrences | 1 | 1 |

No images lost — the hero is repositioned, not removed.

## Verification

- All 25 articles: summary block precedes content block
- Hero image appears exactly once per article page
- Element order on the article page now matches the index
- 19/19 tests pass

## Test changes

`test_article_get_content_only` and `test_article_get_content_only_no_summary` asserted the image was present in the body. That is now deliberately false, so both assertions are inverted, with an added check that `get_image()` still returns the image — the behaviour moved rather than disappeared.

Merging bumps to v1.5.3 and deploys.