### PR TITLE
fix: do not render the article intro twice

### DIFF
--- a/blog/articles.py
+++ b/blog/articles.py
@@ -30,6 +30,10 @@ class Article:
         contents = self.contents.replace(title.group(0), '')
         if summary:
             contents = contents.replace(summary.group(0), '')
+            # Some articles repeat the summary verbatim as their opening
+            # paragraph. That read fine when the summary was not shown on the
+            # article page, but now renders the same text twice.
+            contents = contents.replace(f'<p>{summary.group(1)}</p>', '', 1)
         if image:
             contents = contents.replace(image.group(0), '', 1)
         return contents

--- a/tests/articles/2022-01-01_test-1.md
+++ b/tests/articles/2022-01-01_test-1.md
@@ -4,4 +4,6 @@
 
 ## A test article that has very little inside of it.
 
+A test article that has very little inside of it.
+
 They were just sucked into space. I'm afraid I still don't understand, sir. Travel time to the nearest starbase? A surprise party? Mr. Worf, I hate surprise parties. I would *never* do that to you. Smooth as an android's bottom, eh, Data? Now, how the hell do we defeat an enemy that knows us better than we know ourselves? I recommend you don't fire until you're within 40,000 kilometers. Shields up! Rrrrred alert! And blowing into maximum warp speed, you appeared for an instant to be in two places at once. Wait a minute - you've been declared dead. You can't give orders around here. This is not about revenge. This is about justice. The Federation's gone; the Borg is everywhere! We know you're dealing in stolen ore. But I wanna talk about the assassination attempt on Lieutenant Worf. Talk about going nowhere fast. Fate. It protects fools, little children, and ships named "Enterprise." Did you come here for something in particular or just general Riker-bashing? When has justice ever been as simple as a rule book? Commander William Riker of the Starship Enterprise.

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -48,6 +48,10 @@ def test_article_get_content_only():
     assert '<p>They were just sucked into space.' in sut.get_content_only()
     # The hero image is stripped from the body but still available separately
     assert '<img alt="Placeholder" src="/static/placeholder.png" />' == sut.get_image()
+    # An opening paragraph repeating the summary is dropped, so the article
+    # page does not show the same text twice
+    assert '<p>A test article that has very little inside of it.</p>' \
+        not in sut.get_content_only()
 
 def test_article_get_content_only_no_summary():
     sut = Article('tests/articles/', '2022-01-02_test-2.md')


### PR DESCRIPTION
Follow-up to #135/#136. Four articles have been showing their opening paragraph twice since v1.5.2.

## Cause

These articles repeat the summary verbatim as their first body paragraph:

```markdown
## Since I started driving in 2007 I seem to have run through quite a few cars...

Since I started driving in 2007 I seem to have run through quite a few cars...
```

That read correctly while the summary was stripped from the article page and only the body paragraph rendered. Since v1.5.2 renders the summary as a lead paragraph, both appear — the same text, twice, immediately after the hero image.

Affected: `car-history`, `car-history-part-2`, `car-history-part-3`, `saving-money-with-lambdas`.

## Fix

`get_content_only()` now drops an opening paragraph that exactly matches the summary, so the source files need no editing and future articles written the same way are handled automatically.

Verified by comparing summary text against body text for all 25 articles, not by eye:

```
articles still showing the summary text in the body: 1
  2022-06-02_automated-version-releases  (partial)
```

## The one left alone

`2022-06-02_automated-version-releases` repeats the summary only *partially* — its opening paragraph (487 chars) is a strict prefix of the summary (586 chars), which carries an extra closing sentence. Exact matching deliberately doesn't touch it, and prefix matching would risk eating legitimate content elsewhere.

Deleting the body paragraph would lose nothing, since it's a subset of the summary — but that's an editorial call about your prose rather than a technical one, so I've left it. Say the word and it's a one-line change to the markdown.

## Verification

- 31 tests pass; the `test-1` fixture gained a duplicated paragraph to cover the new behaviour
- pylint clean
- All 25 articles regenerated and checked programmatically