### PR TITLE
feat: validate article structure in CI and fix duplicated intros

### DIFF
--- a/.github/scripts/validate-articles.py
+++ b/.github/scripts/validate-articles.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+'''Fail the build if an article does not follow the expected structure.
+
+The generator finds the title, hero image and summary by position - the
+first h1, the first image, the first h2 - so an article written slightly
+differently renders wrongly rather than failing loudly. This checks the
+convention at pull request time instead.
+
+Expected shape:
+
+    # Title
+
+    ![Alt text](/static/image.jpg)
+
+    ## Summary sentence shown on the index and used as the meta description
+
+    Body...
+
+Later `##` headings are fine; only the first is treated as the summary.
+'''
+import os
+import re
+import sys
+
+ARTICLES_DIR = 'articles'
+STATIC_ROOT = 'blog'
+FILENAME = re.compile(r'^\d{4}-\d{2}-\d{2}_[a-z0-9._-]+\.md$')
+IMAGE = re.compile(r'!\[([^\]]*)\]\(([^)]+)\)')
+MIN_SUMMARY = 40
+
+
+def content_lines(text):
+    '''Lines with fenced code blocks blanked out, so examples inside code
+    samples are not mistaken for real headings or images'''
+    lines, fenced = [], False
+    for line in text.split('\n'):
+        if line.strip().startswith('```'):
+            fenced = not fenced
+            lines.append('')
+            continue
+        lines.append('' if fenced else line)
+    return lines
+
+
+def check(name, lines):
+    problems = []
+    body = [line for line in lines if line.strip()]
+
+    if not body or not body[0].startswith('# '):
+        problems.append('must start with a "# Title" heading')
+        return problems
+
+    if len([line for line in lines if line.startswith('# ')]) != 1:
+        problems.append('must have exactly one "# " title')
+
+    if len(body) < 2 or not body[1].lstrip().startswith('!['):
+        problems.append('needs a hero image directly after the title')
+        return problems
+
+    alt, src = IMAGE.search(body[1]).groups()
+    if not alt.strip():
+        problems.append('hero image needs alt text')
+    if src.startswith('/static/') and not os.path.exists(STATIC_ROOT + src):
+        problems.append(f'hero image {src} does not exist')
+
+    if len(body) < 3 or not body[2].startswith('## '):
+        problems.append('needs a "## " summary directly after the hero image')
+        return problems
+
+    summary = body[2][3:].strip()
+    if len(summary) < MIN_SUMMARY:
+        problems.append(f'summary is only {len(summary)} characters, '
+                        f'expected at least {MIN_SUMMARY}')
+
+    # The summary is rendered above the body, so repeating it anywhere in the
+    # body shows the same text twice - and it is not always the opening
+    # paragraph that repeats it.
+    for index, line in enumerate(body[3:], start=1):
+        paragraph = line.strip()
+        if paragraph.startswith(('#', '!', '|', '>', '-', '*')):
+            continue
+        where = 'opening paragraph' if index == 1 else f'paragraph {index}'
+        if paragraph == summary:
+            problems.append(f'{where} repeats the summary word for word')
+        elif len(paragraph) > MIN_SUMMARY and (
+                summary.startswith(paragraph) or paragraph.startswith(summary)):
+            problems.append(f'{where} largely repeats the summary')
+
+    for alt, src in IMAGE.findall('\n'.join(lines)):
+        if not alt.strip():
+            problems.append(f'image {src} has no alt text')
+        if src.startswith('/static/') and not os.path.exists(STATIC_ROOT + src):
+            problems.append(f'image {src} does not exist')
+
+    return problems
+
+
+def main():
+    failures = {}
+    names = sorted(name for name in os.listdir(ARTICLES_DIR) if name.endswith('.md'))
+
+    for name in names:
+        problems = []
+        if not FILENAME.match(name):
+            problems.append('filename must be YYYY-MM-DD_slug.md')
+        with open(os.path.join(ARTICLES_DIR, name), encoding='UTF-8') as handle:
+            problems.extend(check(name, content_lines(handle.read())))
+        if problems:
+            failures[name] = problems
+
+    print(f'Checked {len(names)} articles')
+
+    if failures:
+        print(f'\n{len(failures)} article(s) need attention:\n')
+        for name, problems in failures.items():
+            print(f'  {name}')
+            for problem in problems:
+                print(f'    ✗ {problem}')
+        print('\nSee the expected structure in .github/scripts/validate-articles.py')
+        return 1
+
+    print('All articles follow the expected structure')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,10 @@ jobs:
         if: steps.version.outputs.should_release == 'true'
         run: |
           python -m pip install -r requirements.txt
+      - name: Validate Articles
+        if: steps.version.outputs.should_release == 'true'
+        run: |
+          python .github/scripts/validate-articles.py
       - name: Generate Distribution
         if: steps.version.outputs.should_release == 'true'
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,6 +94,9 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install -r requirements.txt
+      - name: Validate Articles
+        run: |
+          python .github/scripts/validate-articles.py
       - name: Validate Images
         run: |
           python .github/scripts/validate-images.py

--- a/articles/2022-06-02_automated-version-releases.md
+++ b/articles/2022-06-02_automated-version-releases.md
@@ -4,8 +4,6 @@
 
 ## Choosing the next version for your application or side-project can be a tricky process - when you do increase your major version, and what if your patch number is getting a little high? v1.0.0 looks a lot better than v0.1.567 but what's the best approach? I wanted a way of calculating the version automatically using commit messages and built some generic Groovy scripts that can be used in Jenkins builds to increment a version automatically when I merge a PR or push straight to main. This shows the code samples I've put together and how I've been using this privately up until now.
 
-Choosing the next version for your application or side-project can be a tricky process - when you do increase your major version, and what if your patch number is getting a little high? v1.0.0 looks a lot better than v0.1.567 but what's the best approach? I wanted a way of calculating the version automatically using commit messages and built some generic Groovy scripts that can be used in Jenkins builds to increment a version automatically when I merge a PR or push straight to main.
-
 Part of this was to have a path of CI and CD for my side projects, blog and infrastructure; but part of it was to take the hard work out of semantic versioning and determining the correct approach to recording this, providing a consistent approach for everything I put together.
 
 ### Semantic Versioning

--- a/articles/2022-08-07_car-history.md
+++ b/articles/2022-08-07_car-history.md
@@ -4,8 +4,6 @@
 
 ## Since I started driving in 2007 I seem to have run through quite a few cars, and more than anything I wanted to get a little bit written on them in one place. I've had 14 cars over the years, 2 of which I still have. I tend to change them fairly often, but some I keep longer than others if I form a bit more of an affinity with them. Anyway, I thought a run through what I've had might be interesting for someone at the very least.
 
-Since I started driving in 2007 I seem to have run through quite a few cars, and more than anything I wanted to get a little bit written on them in one place. I've had 14 cars over the years, 2 of which I still have. I tend to change them fairly often, but some I keep longer than others if I form a bit more of an affinity with them. Anyway, I thought a run through what I've had might be interesting for someone at the very least.
-
 I realised most of the way through that this was getting a little long, so I've split the post into 3 - that way it's a little easier to digest.
 
 ### 1. 1994 Nissan Micra 1.3 LX (M743 GFT)

--- a/articles/2022-08-15_car-history-part-2.md
+++ b/articles/2022-08-15_car-history-part-2.md
@@ -4,8 +4,6 @@
 
 ## Continuing the last post, part 2 details some newer cars when I was having a little more of a "sensible" period, but that didn't last long...
 
-Continuing the last post, part 2 details some newer cars when I was having a little more of a "sensible" period, but that didn't last long...
-
 If you missed [part 1](/2022-08-07_car-history), I suggest reading that first.
 
 ### 6. 2011 Skoda Fabia VRS (BG61 ODL)

--- a/articles/2022-08-22_car-history-part-3.md
+++ b/articles/2022-08-22_car-history-part-3.md
@@ -4,8 +4,6 @@
 
 ## Or the tale of two Land Rover Discoverys... The final part of my car history, including what I'm driving around in today (correct as of August 2022).
 
-Or the tale of two Land Rover Discoverys... The final part of my car history, including what I'm driving around in today (correct as of August 2022).
-
 I'd recommend reading [part 1](/2022-08-07_car-history) and [part 2](/2022-08-15_car-history-part-2) first if you haven't already.
 
 ### 10. 2000 Toyota Avensis 1.8 CDX (W281 LMS)

--- a/articles/2022-11-18_devhub-north.md
+++ b/articles/2022-11-18_devhub-north.md
@@ -6,8 +6,6 @@
 
 I don't often post about my day job as a principal engineer at Tesco Bank, but this is a special case.
 
-A few weeks ago, I had the opportunity to speak at the first DevHub North post-pandemic about the journey so far at Tesco Bank Technology, and how far we've come in a few years.
-
 It was fantastic to stand in front of 150 or so people and explain where we'd come from and where we're going with highlights such as distributed working, containers, our Insurance plan and where we're going next.
 
 The tam were kind enough to post it on YouTube, so take a look if you're interested: [https://www.youtube.com/watch?v=saY2IwJquhE](https://www.youtube.com/watch?v=saY2IwJquhE)

--- a/articles/2023-07-23_saving-money-with-lambdas.md
+++ b/articles/2023-07-23_saving-money-with-lambdas.md
@@ -4,8 +4,6 @@
 
 ## I host this website and my Jenkins setup on AWS, and have detailed in the past how I [automate the setup of this](/2022-01-15_terraform-and-ansible). However, running an EC2 24/7 to handle occasional CI builds for personal projects didn't seem like the best idea, and I wanted to see if I could save money by thinking the process through a bit. This explains how I used AWS lambdas to automate the started of an EC2 through the AWS CLI, and how to set this up within GitHub and Jenkins to drop your single EC2 instance bill by around 90-95%.
 
-I host this website and my Jenkins setup on AWS, and have detailed in the past how I [automate the setup of this](/2022-01-15_terraform-and-ansible). However, running an EC2 24/7 to handle occasional CI builds for personal projects didn't seem like the best idea, and I wanted to see if I could save money by thinking the process through a bit. This explains how I used AWS lambdas to automate the started of an EC2 through the AWS CLI, and how to set this up within GitHub and Jenkins to drop your single EC2 instance bill by around 90-95%.
-
 ### The Plan
 
 To make sure this was going to cover everything I used the Jenkins instance for, along with saving some money, it had to have some relatively clear requirements:

--- a/blog/articles.py
+++ b/blog/articles.py
@@ -30,10 +30,6 @@ class Article:
         contents = self.contents.replace(title.group(0), '')
         if summary:
             contents = contents.replace(summary.group(0), '')
-            # Some articles repeat the summary verbatim as their opening
-            # paragraph. That read fine when the summary was not shown on the
-            # article page, but now renders the same text twice.
-            contents = contents.replace(f'<p>{summary.group(1)}</p>', '', 1)
         if image:
             contents = contents.replace(image.group(0), '', 1)
         return contents

--- a/tests/articles/2022-01-01_test-1.md
+++ b/tests/articles/2022-01-01_test-1.md
@@ -4,6 +4,4 @@
 
 ## A test article that has very little inside of it.
 
-A test article that has very little inside of it.
-
 They were just sucked into space. I'm afraid I still don't understand, sir. Travel time to the nearest starbase? A surprise party? Mr. Worf, I hate surprise parties. I would *never* do that to you. Smooth as an android's bottom, eh, Data? Now, how the hell do we defeat an enemy that knows us better than we know ourselves? I recommend you don't fire until you're within 40,000 kilometers. Shields up! Rrrrred alert! And blowing into maximum warp speed, you appeared for an instant to be in two places at once. Wait a minute - you've been declared dead. You can't give orders around here. This is not about revenge. This is about justice. The Federation's gone; the Borg is everywhere! We know you're dealing in stolen ore. But I wanna talk about the assassination attempt on Lieutenant Worf. Talk about going nowhere fast. Fate. It protects fools, little children, and ships named "Enterprise." Did you come here for something in particular or just general Riker-bashing? When has justice ever been as simple as a rule book? Commander William Riker of the Starship Enterprise.

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -48,10 +48,6 @@ def test_article_get_content_only():
     assert '<p>They were just sucked into space.' in sut.get_content_only()
     # The hero image is stripped from the body but still available separately
     assert '<img alt="Placeholder" src="/static/placeholder.png" />' == sut.get_image()
-    # An opening paragraph repeating the summary is dropped, so the article
-    # page does not show the same text twice
-    assert '<p>A test article that has very little inside of it.</p>' \
-        not in sut.get_content_only()
 
 def test_article_get_content_only_no_summary():
     sut = Article('tests/articles/', '2022-01-02_test-2.md')


### PR DESCRIPTION
Your approach rather than mine — enforce the existing conventions in CI instead of migrating every article to front matter.

## Why this instead of front matter

The generator finds the title, hero image and summary by position: the first `h1`, the first image, the first `h2`. Those rules live only in regexes, so an article written slightly differently renders wrongly rather than failing. Front matter would make the convention *declared*; a validator makes it *enforced*, which is worth more and costs one script instead of rewriting 25 files.

For the record, one of my three arguments for front matter was simply wrong. I claimed the summary rendered as an `<h2>` that screen readers would announce as a heading. It doesn't — there are **zero `<h2>` tags** in the rendered output for it. The `##` is a source marker that never reaches HTML, and I asserted a rendering consequence without checking the output.

## What the validator checks

- Filename is `YYYY-MM-DD_slug.md`
- Exactly one `# ` title, and it comes first
- A hero image directly after the title, with alt text, resolving to a real file
- A `## ` summary directly after the hero image, at least 40 characters
- No body paragraph repeats the summary
- Every image in the article has alt text and exists

Fenced code blocks are blanked before parsing — the static site generator article contains a markdown example with `## ` and `/static/image.png` in it, and a naive scan flags both as real. My first pass did exactly that.

Later `##` headings are allowed. One article uses `## Final` as a section heading, and forcing it to `###` would change rendering for no benefit.

Proven to fail rather than assumed:

```
✗ hero image needs alt text
✗ hero image /static/nope-does-not-exist.jpg does not exist
✗ opening paragraph repeats the summary word for word
exit=1
```

Runs in `Test` on every PR, and in `Build` before generation so a direct push can't produce a broken site.

## The dedup workaround is gone

Six articles repeated their summary in the body. They're fixed at source, so `get_content_only()` no longer strips the duplicate at render time — CI prevents the problem rather than the renderer hiding it.

## How the sixth was found

Five were already known. I diffed the rendered text of all 32 pages before and after, and `devhub-north` **gained** 178 characters — an article I hadn't touched. It repeats its summary as the *second* paragraph, not the first, so the dedup had been silently deleting it and my validator only checked the opening paragraph. The validator now checks every paragraph.

That check was worth more than every other verification step here.

## Net effect on the site

| | |
| --- | --- |
| Pages whose rendered text changes | **1 of 32** |
| `automated-version-releases` | −488 chars (the paragraph duplicating its summary) |
| Other 31 pages | byte for byte identical |

## Verification

- All 25 articles pass; validator proven to fail on a deliberately broken one
- Before/after rendered-text diff across all 32 pages
- `devhub-north` rendered in a browser to confirm it reads correctly
- 36 tests pass, coverage 97.9% line / 89.6% branch (gates 80/70), pylint 9.60/10

## Front matter

Deferred entirely. When you want tags, it can be added as a single optional field on the articles that need it — the meta extension tolerates missing keys, so there's no migration in that path either. I framed it as a big-bang change when it never needed to be one.