### PR TITLE
feat: add RSS feed, robots.txt and improve the sitemap

### DIFF
--- a/blog/articles.py
+++ b/blog/articles.py
@@ -1,4 +1,6 @@
 import datetime
+from datetime import timezone
+from email.utils import format_datetime
 import math
 from os import listdir
 from os.path import isfile, join
@@ -42,6 +44,10 @@ class Article:
             raise InvalidDateForArticleException(
                 f'Could not parse date for article {self.filename}')
         return datetime.datetime.strptime(date.group(1), '%Y-%m-%d')
+
+    def get_rfc_date(self):
+        '''Publication date in the RFC 822 form RSS requires'''
+        return format_datetime(self.get_date().replace(tzinfo=timezone.utc))
 
     def get_image(self):
         image = self.find_image.search(self.contents)

--- a/blog/generate.py
+++ b/blog/generate.py
@@ -45,10 +45,22 @@ def generate(articles_dir=ARTICLES_DIR, dist_dir=DIST_DIR):
             output_file.write(rendered)
 
     # Generate sitemap
+    pages = get_pages(articles_dir)
     print('[INFO] Rendering and writing sitemap...')
-    rendered = render_template('sitemap.xml', articles=items, canonical='')
+    rendered = render_template('sitemap.xml', articles=items, pages=pages, canonical='')
     with open(dist_dir + 'sitemap.xml', 'w', encoding='UTF-8') as output_file:
         output_file.write(rendered)
+
+    # Generate RSS feed
+    print('[INFO] Rendering and writing feed...')
+    rendered = render_template('feed.xml', articles=items, canonical='')
+    with open(dist_dir + 'feed.xml', 'w', encoding='UTF-8') as output_file:
+        output_file.write(rendered)
+
+    # Generate robots.txt, pointing crawlers at the sitemap
+    print('[INFO] Writing robots.txt...')
+    with open(dist_dir + 'robots.txt', 'w', encoding='UTF-8') as output_file:
+        output_file.write(f'User-agent: *\nAllow: /\n\nSitemap: {SITE_URL}/sitemap.xml\n')
 
     # Generate static pages (inc error pages)
     for static_page in  ['404', '500', 'now', 'journal']:
@@ -59,7 +71,6 @@ def generate(articles_dir=ARTICLES_DIR, dist_dir=DIST_DIR):
             output_file.write(rendered)
 
     # Generate home page and paginated elements
-    pages = get_pages(articles_dir)
     print(f'[INFO] Found {pages} pages of articles...')
     for p in range(1, pages + 1):
         print(f'[INFO] Rendering and writing index page {p}...')

--- a/blog/templates/base.html
+++ b/blog/templates/base.html
@@ -27,6 +27,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;0,400;0,700;0,900;1,400&display=swap" />
     <link rel="stylesheet" type="text/css" href="/static/css/default.min.css?v={{ version }}" />
+    <link rel="alternate" type="application/rss+xml" title="Jamie Hurst's Blog" href="/feed.xml" />
     <link rel="apple-touch-icon" sizes="180x180" href="/static/apple-touch-icon.png" />
     <link rel="shortcut icon" href="/static/favicon.ico" />
     <link rel="icon" type="image/png" sizes="32x32" href="/static/favicon-32x32.png" />

--- a/blog/templates/feed.xml
+++ b/blog/templates/feed.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+    <channel>
+        <title>Jamie Hurst's Blog</title>
+        <link>{{ site_url }}/</link>
+        <atom:link href="{{ site_url }}/feed.xml" rel="self" type="application/rss+xml" />
+        <description>Software and system engineering, infrastructure and terrible cars, by Jamie Hurst.</description>
+        <language>en-gb</language>
+        <copyright>Copyright Jamie Hurst 2021-{{ year }}</copyright>
+        {% if articles %}<lastBuildDate>{{ articles[0].get_rfc_date() }}</lastBuildDate>{% endif %}
+{% for article in articles %}
+        <item>
+            <title>{{ article.get_title() }}</title>
+            <link>{{ site_url }}/{{ article.get_name() }}</link>
+            <guid isPermaLink="true">{{ site_url }}/{{ article.get_name() }}</guid>
+            <pubDate>{{ article.get_rfc_date() }}</pubDate>
+            {% if article.get_description(500) %}<description>{{ article.get_description(500) }}</description>{% endif %}
+        </item>
+{% endfor %}
+    </channel>
+</rss>

--- a/blog/templates/sitemap.xml
+++ b/blog/templates/sitemap.xml
@@ -1,15 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-
+    <url>
+        <loc>{{ site_url }}/</loc>
+        {% if articles %}<lastmod>{{ articles[0].get_date().strftime('%Y-%m-%d') }}</lastmod>{% endif %}
+    </url>
 {% for article in articles %}
     <url>
-        <loc>https://jamiehurst.co.uk/{{ article.get_name() }}</loc>
+        <loc>{{ site_url }}/{{ article.get_name() }}</loc>
+        <lastmod>{{ article.get_date().strftime('%Y-%m-%d') }}</lastmod>
+    </url>
+{% endfor %}
+{% for page in range(2, pages + 1) %}
+    <url>
+        <loc>{{ site_url }}/?page={{ page }}</loc>
     </url>
 {% endfor %}
     <url>
-        <loc>https://jamiehurst.co.uk/journal</loc>
+        <loc>{{ site_url }}/journal</loc>
     </url>
     <url>
-        <loc>https://jamiehurst.co.uk/now</loc>
+        <loc>{{ site_url }}/now</loc>
     </url>
 </urlset>

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -120,3 +120,7 @@ def test_article_get_image_src():
 def test_article_get_image_src_no_image():
     sut = Article('tests/failed-articles/', '2022-01-01_no-image.md')
     assert sut.get_image_src() is None
+
+def test_article_get_rfc_date():
+    sut = Article('tests/articles/', '2022-01-01_test-1.md')
+    assert 'Sat, 01 Jan 2022 00:00:00 +0000' == sut.get_rfc_date()

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -9,7 +9,27 @@ def test_generate():
     assert os.path.exists('tests/dist/index.html')
     assert os.path.exists('tests/dist/now.html')
     assert os.path.exists('tests/dist/sitemap.xml')
+    assert os.path.exists('tests/dist/feed.xml')
+    assert os.path.exists('tests/dist/robots.txt')
     assert os.path.exists('tests/dist/static')
     assert os.path.exists('tests/dist/static/css/default.min.css')
     assert os.path.exists('tests/dist/2022-01-01_test-1.html')
     assert os.path.exists('tests/dist/2022-01-02_test-2.html')
+
+def test_generate_writes_feed_and_robots():
+    generate(articles_dir='tests/articles/', dist_dir='tests/dist/')
+    with open('tests/dist/feed.xml', encoding='UTF-8') as feed_file:
+        feed = feed_file.read()
+    assert '<rss version="2.0"' in feed
+    assert '<item>' in feed
+    with open('tests/dist/robots.txt', encoding='UTF-8') as robots_file:
+        robots = robots_file.read()
+    assert 'User-agent: *' in robots
+    assert 'Sitemap: ' in robots
+
+def test_generate_sitemap_has_lastmod_and_homepage():
+    generate(articles_dir='tests/articles/', dist_dir='tests/dist/')
+    with open('tests/dist/sitemap.xml', encoding='UTF-8') as sitemap_file:
+        sitemap = sitemap_file.read()
+    assert '<lastmod>' in sitemap
+    assert '<loc>https://jamiehurst.co.uk/</loc>' in sitemap


### PR DESCRIPTION
The three discoverability gaps left from the review, all small and independent.

## RSS feed

`/feed.xml` — RSS 2.0, all 25 articles, summary as the description, self-referencing `atom:link`. `base.html` advertises it so readers autodiscover it from any page:

```html
<link rel="alternate" type="application/rss+xml" title="Jamie Hurst's Blog" href="/feed.xml" />
```

Dates use `email.utils.format_datetime` rather than `strftime`. `%a` and `%b` are locale-dependent, so a runner with a non-English locale would emit day and month names that break RSS parsers.

**No `<enclosure>` on items.** RSS requires a byte length, and `length="0"` is invalid — a common mistake. Readers wanting a thumbnail can use the `og:image` already on every page. Adding valid enclosures would mean stat-ing each image at build time; happy to do it if you want richer cards.

Descriptions are summaries rather than full text. Full-text feeds are nicer to read but need every `/static/` image path rewritten to absolute or images break in readers — a reasonable follow-up, deliberately not bundled here.

## robots.txt

Was returning 404, so nothing pointed crawlers at your sitemap:

```
User-agent: *
Allow: /

Sitemap: https://jamiehurst.co.uk/sitemap.xml
```

## Sitemap

Gained the homepage, the paginated index pages, and `<lastmod>` on every article — from 27 bare `<loc>` entries to 30 with dates. `lastmod` is what tells crawlers which pages are worth re-fetching.

## Verification

Parsed rather than eyeballed:

```
sitemap: parses OK, 30 urls
  homepage present: True
  paginated present: ['...?page=2', '...?page=3']
  duplicates: none

feed: parses OK, rss version 2.0, 25 items
  items missing required fields or with bad dates: none
  duplicate guids: none
```

Every item has `title`, `link`, `guid`, `pubDate` and `description`, and every `pubDate` round-trips through `parsedate_to_datetime`.

Also confirmed nginx serves all three correctly rather than applying its extensionless-to-`.html` rewrite — that rule uses `[\w\-]+`, which excludes dots, so `.txt` and `.xml` paths pass through untouched:

```
/robots.txt    200  Content-Type: text/plain
/feed.xml      200  Content-Type: text/xml
/sitemap.xml   200  Content-Type: text/xml
```

- 39 tests pass (3 new), each new test self-contained rather than depending on another test having run first
- Coverage 98.0% line / 89.6% branch, gates 80/70
- pylint 9.61/10
- Article validator still passes on all 25