### PR TITLE
fix: do not let deployment bookkeeping block the deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,9 +30,12 @@ jobs:
           cond: ${{ ! contains(inputs.version, '.') }}
           if_true: ${{ steps.latest.outputs.name }}
           if_false: ${{ inputs.version }}
-      - uses: chrnorm/deployment-action@releases/v1
+      # Recording the deployment in GitHub is bookkeeping - it must never
+      # stop the site from actually shipping, so failures here are tolerated.
+      - uses: chrnorm/deployment-action@v2.0.8
         name: Create deployment for ${{ steps.version.outputs.value }}
         id: deployment
+        continue-on-error: true
         with:
           token: ${{ secrets.PAT }}
           description: ${{ steps.version.outputs.value }}
@@ -53,7 +56,8 @@ jobs:
             ln -s blog-${{ steps.version.outputs.value }} blog
             service nginx reload
       - name: Update deployment status (success)
-        if: success()
+        if: success() && steps.deployment.outputs.deployment_id
+        continue-on-error: true
         uses: chrnorm/deployment-status@v2
         with:
           token: ${{ secrets.PAT }}
@@ -61,7 +65,8 @@ jobs:
           state: success
           deployment-id: ${{ steps.deployment.outputs.deployment_id }}
       - name: Update deployment status (failure)
-        if: failure()
+        if: failure() && steps.deployment.outputs.deployment_id
+        continue-on-error: true
         uses: chrnorm/deployment-status@v2
         with:
           token: ${{ secrets.PAT }}


### PR DESCRIPTION
**v1.8.0 was built and released but never reached the server.** The site is still serving v1.7.0, and `/feed.xml` and `/robots.txt` from #141 are 404.

## What happened

The Deploy job's first step records a Deployment object in GitHub for the environments UI. It failed on a TLS error:

```
HttpError: request to https://api.github.com/repos/jamiefdhurst/blog/deployments/5867397108/statuses
failed, reason: self-signed certificate
```

`chrnorm/deployment-action` was pinned to `releases/v1` — a moving tag from the v1 era that targets Node 20 and is now force-run on Node 24. The current release is v2.0.8.

Because that step failed, everything after it was skipped:

```
success  Resolve version
failure  Create deployment for v1.8.0
skipped  Upload release v1.8.0 to server   ← the actual deploy
skipped  Update deployment status (success)
```

A cosmetic API call for a GitHub UI panel took the entire deployment down with it. The release artifact was fine — it just never got uploaded.

## Fix

- **Pinned to `@v2.0.8`**, matching the status action already on `@v2`, and to an immutable tag rather than a moving one
- **`continue-on-error: true`** on all three bookkeeping steps, so a GitHub API problem can never again stop the site shipping
- **Status steps now require a deployment id** — they can't report on a deployment that was never created, which is why the failure-status step *also* errored with `Not Found`

The SSH upload step is untouched. It remains the step that determines whether the job succeeds.

## After merging

Merging this won't redeploy on its own — `Build` only fires on pushes touching `*.py`, `*.md`, `articles/**`, `blog/**`, `docker/**`, `tests/**`, `requirements.txt` or `setup.cfg`, and `.github/workflows/**` isn't in that list, so `Deploy` won't chain.

I'll trigger `Deploy` manually via `workflow_dispatch` afterwards to ship **v1.8.0**, which already contains the feed, robots.txt and sitemap changes.